### PR TITLE
devcontainer Update (Formatmigration + Spellchecker)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,9 @@
         "dbaeumer.vscode-eslint",
         "editorconfig.editorconfig",
         "davidanson.vscode-markdownlint",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "streetsidesoftware.code-spell-checker",
+        "streetsidesoftware.code-spell-checker-german"
       ]
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,15 +9,19 @@
       "VARIANT": "20.16-bullseye"
     }
   },
-  // Set *default* container specific settings.json values on container create.
-  "settings": {},
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "dbaeumer.vscode-eslint",
-    "editorconfig.editorconfig",
-    "davidanson.vscode-markdownlint",
-    "eamodio.gitlens"
-  ],
+  "customizations": {
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {},
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig",
+        "davidanson.vscode-markdownlint",
+        "eamodio.gitlens"
+      ]
+    }
+  },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [
     4000,

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2",
+  "language": "de,en",
+  "enabledLanguageIds": [
+    "markdown"
+  ],
+  "minWordLength": 2,
+  "allowCompoundWords": true,
+  "words": [
+    "ABAP",
+    "abapGit",
+    "DSAG",
+    "HANA",
+    "S/4HANA",
+    "SAP",
+    "ERP",
+    "OSS"
+  ],
+  "flagWords": [
+    "S4HANA",
+    "S4/HANA"
+  ]
+}


### PR DESCRIPTION
Ich habe noch keine Möglichkeit gesehen code-spell-checker in GitHub Actions zu integrieren, aber die Konfigurationsdatei sollte im Zweifel auf ein anderes Tool einfach zu migrieren sein.