### PR TITLE
Vim zu Dev Container hinzufügen

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workspace
 
 # Install necessary packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends curl gnupg ruby-full
+    && apt-get -y install --no-install-recommends curl gnupg ruby-full vim
 
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
Hier ein Vorschlag, vim im Dev Container hinzuzufügen - ich benutze git gerne in der Kommandozeile, aber z.B. das normale `git commit` oder auch ein interactive rebase funktionieren ohne installierten Editor nicht, und git nutzt vim als default.