### PR TITLE
Automatische Bestimmung der Navigation letzte/nächste Seite

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -58,15 +58,6 @@ Es gibt verschiedene Metadaten (siehe [Front Matter](https://jekyllrb.com/docs/f
 | parent       | Bezeichnung der übergeordneten Seite (`title`-Attribut) falls die Seite eine Unterseite ist                      |
 | grand_parent | Bezeichnung der übergeordneten Seite in der 3. Stufe - siehe `parent`                                            |
 
-Außerdem gibt es noch die folgenden Einstellungen für die Navigation im Fußbereich einer Seite, um zur nächsten bzw. voherigen Kapitel navigieren zu können.
-
-| Einstellung     | Beschreibung                                                                             |
-| --------------- | ---------------------------------------------------------------------------------------- |
-| next_page_link  | `permalink` auf die nächste Seite                                                        |
-| next_page_title | Titel der nächsten Seite. Kann vom Wert des `title`-Attributes der Zielseite abweichen   |
-| prev_page_link  | `permalink` auf die vorherige Seite                                                      |
-| prev_page_title | Titel der vorherigen Seite. Kann vom Wert des `title`-Attributes der Zielseite abweichen |
-
 Beispiel:
 
 ```text
@@ -76,10 +67,6 @@ title: ABAP Views
 parent: Funktionen von ADT
 grand_parent: Arbeiten mit ADT
 permalink: /working-with-adt/features/abap-views/
-prev_page_link: /working-with-adt/features/other-object-types/
-prev_page_title: Andere Objekttypen
-next_page_link: /working-with-adt/features/refactoring/
-next_page_title: Refactoring
 nav_order: 5
 ---
 ```

--- a/docs/_includes/find_idx_by_title
+++ b/docs/_includes/find_idx_by_title
@@ -1,0 +1,16 @@
+{%- comment -%}
+This include has two parameters:
+title:  title of page to search for
+pages:  array of pages to search
+
+It will either print the index of the page with provided title in the given array, or nothing.
+
+You can use the result by capturing it.
+{%- endcomment -%}
+
+{%- for _p in include.pages -%}
+    {%- if _p.title == include.title -%}
+        {{ forloop.index0 }}
+        {%- break -%}
+    {%- endif -%}
+{%- endfor -%} 

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -14,22 +14,22 @@
 
 {% comment %} 
     Add navigation to next/previous page 
-{% endcomment %} 
-{% if page.next_page_link or page.prev_page_link %}
+{% endcomment %}
+
+{% include get_page_navigation %}
+
+{% if previous_page or next_page %}
 <p style="padding-bottom: 3em">
-    {% if page.prev_page_link %}
+    {% if previous_page %}
     <span class="prev float-left">
         ←
-        <a href="{{site.baseurl}}{{ page.prev_page_link }}"
-            >{{ page.prev_page_title }}</a
-        >
+        <a href="{% link {{ previous_page.path }} %}">{{ previous_page.title }}</a>
     </span>
     {% endif %} 
-    {% if page.next_page_link %}
-    <span class="next float-right"
-        ><a href="{{site.baseurl}}{{ page.next_page_link }}"
-            >{{ page.next_page_title }}</a
-        >
+
+    {% if next_page %}
+    <span class="next float-right">
+        <a href="{% link {{ next_page.path }} %}">{{ next_page.title }}</a>
         →
     </span>
     {% endif %}

--- a/docs/_includes/get_page_navigation
+++ b/docs/_includes/get_page_navigation
@@ -1,0 +1,154 @@
+{%- comment -%}
+This include creates the following variables:
+
+is_top_page:        true if current page is top page
+
+has_children:       true if current page is a top page that has children
+
+top_pages:          array with all top-level page objects, ordered by nav_order
+                    e.g. [Introduction, Development, ...]
+
+top_child_pages:    array of array of pages, first array has same index as top pages,
+                    inner array contains direct children sorted by nav_order
+                    e.g. [[], [Dev1, Dev2], ...]
+
+next_page:          next page in nav order
+
+previous_page:      previous page in nav order (or parent, if it is the first page)
+
+{%- endcomment -%}
+
+{%- comment -%}
+=== top_pages ===
+{%- endcomment -%}
+
+{% assign top_pages = site.pages
+| where_exp: "item", "item.title != nil and item.parent == nil"
+| sort: "nav_order"
+%}
+
+
+{%- comment -%}
+=== is_top_page ===
+{%- endcomment -%}
+
+{% assign _first_filtered = top_pages | where_exp: "item", "item.title == page.title" | first %}
+{% if _first_filtered %}
+{% assign is_top_page = 1 %}
+{% else %}
+{% assign is_top_page = 0 %}
+{% endif %}
+
+{%- comment -%}
+=== top_child_pages ===
+{%- endcomment -%}
+
+{% assign top_child_pages = "" | split: "," %}
+
+{% for top_page in top_pages %}
+    {% assign _curr_children = site.pages
+    | where_exp: "item", "item.title != nil and item.parent == top_page.title"
+    | sort: "nav_order" %}
+
+    {% assign top_child_pages = top_child_pages | push: _curr_children %}
+{% endfor %}
+
+
+{%- comment -%}
+=== has children ===
+{%- endcomment -%}
+
+{% if is_top_page == 1 %}
+    {% assign _children_of_this_page = site.pages
+        | where_exp: "item", "item.title != nil and item.parent == page.title"
+        | sort: "nav_order" %}
+    {% assign first_child = _children_of_this_page | first %}
+{% endif %}
+
+
+{%- comment -%}
+=== next_page / last_page ===
+{%- endcomment -%}
+
+{% if is_top_page == 1%}
+
+
+    {%comment%} +++ read index of current page from top_pages array +++ {%endcomment%}
+
+    {% capture _my_idx_str -%}
+    {% include find_idx_by_title pages=top_pages title=page.title %}
+    {%- endcapture %}
+
+    {% if _my_idx_str != "" # only convert if not empty string %}
+    {% assign _my_idx = _my_idx_str | plus: 0%}
+    {% endif %}
+
+
+    {%comment%} +++ determine next page in navigation +++ {%endcomment%}
+    
+    {% assign _next_top_page = top_pages | where_exp: "item", "item.nav_order > page.nav_order" | first %}
+
+    {% assign _my_children = top_child_pages[_my_idx] %}
+    {% assign _my_first_child = _my_children | first %}
+
+    {% if _my_first_child != nil %}
+        {% assign _next_child_or_top_page = _my_first_child %}
+    {% else %}
+        {% assign _next_child_or_top_page = _next_top_page %}
+    {% endif %}
+
+    {%comment%}
+        set to _next_top_page so top pages always link to next top page, 
+        or _next_child_or_top_page to link to the next child of the this
+        top page, if possible
+    {%endcomment%}
+    {% assign next_page = _next_child_or_top_page %}
+    
+
+    {%comment%} +++ determine previous page in navigation +++{%endcomment%}
+    {% assign _previous_top_page = top_pages | where_exp: "item", "page.nav_order > item.nav_order" | last %}
+    {% assign _parent_predecessor = _my_idx|minus:1 %}
+
+    {% if _parent_predecessor >= 0 %}
+        {% assign _parent_predecessor_children = top_child_pages[_parent_predecessor] %}
+        {% assign _num_parent_predecessor_children = _parent_predecessor_children | size %}
+
+        {% if _num_parent_predecessor_children == 0 %}
+            {% assign _previous_child_or_top_page = top_pages[_parent_predecessor] %}
+        {% else %}
+            {% assign _previous_child_or_top_page = _parent_predecessor_children[-1] %}
+        {% endif %}
+    {% endif %}
+
+    {%comment%}
+        set to _pervious_top_page so top pages always link to previous top page, 
+        or _previous_child_or_top_page to link to the last child of the previous
+        top page, if possible
+    {%endcomment%}
+    {% assign previous_page = _previous_child_or_top_page %}
+{% else %}
+
+    {% capture _parent_idx_str -%}
+    {% include find_idx_by_title pages=top_pages title=page.parent %}
+    {%- endcapture %}
+    
+    {% if _parent_idx_str != "" # only convert if not empty string %}
+    {% assign _parent_idx = _parent_idx_str | plus: 0%}
+    {% endif %}
+
+    {% if _parent_idx %}
+        {% assign _siblings = top_child_pages[_parent_idx] %}
+
+        {% assign next_page     = _siblings | where_exp: "item", "item.nav_order > page.nav_order" | first %}
+        {% assign previous_page = _siblings | where_exp: "item", "page.nav_order > item.nav_order" | last %}
+    {% endif %}
+
+    {% if previous_page == Nil && _parent_idx %}
+        {% assign previous_page = top_pages[_parent_idx] %}
+    {% endif %}
+    
+    {% if next_page == nil && _parent_idx %}
+        {% assign _parent_successor = _parent_idx|plus:1  %}
+        {% assign next_page = top_pages[_parent_successor] %}
+    {% endif %}
+{% endif %}

--- a/docs/abap/architecture_and_design.md
+++ b/docs/abap/architecture_and_design.md
@@ -3,10 +3,6 @@ layout: page
 title: Architektur und Design moderner ABAP Entwicklungen
 permalink: /abap/architecture_and_design/
 parent: Moderne ABAP Entwicklung
-prev_page_link: /abap/
-prev_page_title: Moderne ABAP Entwicklung
-next_page_link: /abap/clean_and_modern_abap/
-next_page_title: Sauberer und moderner ABAP Code
 nav_order: 1
 ---
 

--- a/docs/abap/clean_and_modern_abap.md
+++ b/docs/abap/clean_and_modern_abap.md
@@ -3,10 +3,6 @@ layout: page
 title: Sauberen und modernen ABAP Code schreiben
 permalink: /abap/clean_and_modern_abap/
 parent: Moderne ABAP Entwicklung
-prev_page_link: /abap/architecture_and_design/
-prev_page_title: Architektur und Design moderner ABAP Anwendungen
-next_page_link: /abap/restful_abap/
-next_page_title: Das Restful ABAP Programming Model (RAP)
 nav_order: 2
 ---
 

--- a/docs/abap/enabling_modern_development.md
+++ b/docs/abap/enabling_modern_development.md
@@ -3,8 +3,6 @@ layout: page
 title: Rahmenbedingungen und Enabling moderne ABAP Entwicklung im  Unternehmen und in den Teams
 permalink: /abap/enabling_modern_development/
 parent: Moderne ABAP Entwicklung
-prev_page_link: /abap/restful_abap/
-prev_page_title: Das ABAP Restful Application Programming Model (RAP)
 nav_order: 4
 ---
 

--- a/docs/abap/index.md
+++ b/docs/abap/index.md
@@ -2,8 +2,6 @@
 layout: page
 title: Moderne ABAP Entwicklung
 permalink: /abap/
-next_page_link: /abap/architecture_and_design/
-next_page_title: Architektur und Design moderner ABAP Entwicklung
 has_children: true
 nav_order: 3
 ---

--- a/docs/abap/restful_abap.md
+++ b/docs/abap/restful_abap.md
@@ -3,10 +3,6 @@ layout: page
 title: Das ABAP Restful Application Programming Model (RAP)
 permalink: /abap/restful_abap/
 parent: Moderne ABAP Entwicklung
-prev_page_link: /abap/clean_and_modern_abap/
-prev_page_title: Sauberer und moderner ABAP Code
-next_page_link: /abap/enabling_modern_development/
-next_page_title: Rahmenbedingungen und Enabling moderne ABAP Entwicklung im Team
 nav_order: 3
 ---
 

--- a/docs/application-lifecycle-management/ensuring-quality.md
+++ b/docs/application-lifecycle-management/ensuring-quality.md
@@ -3,8 +3,6 @@ layout: page
 title: Qualitätssicherung und -Monitoring
 permalink: /application-lifecycle-management/ensuring-quality/
 parent: ALM
-prev_page_link: /application-lifecycle-management/success-factors/
-prev_page_title: Rahmenbedingungen für ein erfolgreiches ALM
 nav_order: 2
 ---
 

--- a/docs/application-lifecycle-management/index.md
+++ b/docs/application-lifecycle-management/index.md
@@ -2,7 +2,6 @@
 layout: page
 title: ALM
 permalink: /application-lifecycle-management/
-next_page_title: ALM
 nav_order: 4
 ---
 

--- a/docs/application-lifecycle-management/success-factors.md
+++ b/docs/application-lifecycle-management/success-factors.md
@@ -3,8 +3,6 @@ layout: page
 title: Rahmenbedingungen für ein erfolgreiches ALM
 permalink: /application-lifecycle-management/success-factors/
 parent: ALM
-next_page_link: /application-lifecycle-management/ensuring-quality/
-next_page_title: Qualitätssicherung und -Monitoring
 nav_order: 1
 ---
 

--- a/docs/artificial-intelligence/index.md
+++ b/docs/artificial-intelligence/index.md
@@ -2,8 +2,7 @@
 layout: page
 title: Künstliche Intelligenz
 permalink: /artificial-intelligence/
-next_page_title: Künstliche Intelligenz
-nav_order: 12
+nav_order: 13
 ---
 
 {: .no_toc}

--- a/docs/authors/index.md
+++ b/docs/authors/index.md
@@ -2,8 +2,7 @@
 layout: page
 title: Autoren & Reviewer
 permalink: /authors/
-next_page_title: Autoren & Reviewer
-nav_order: 14
+nav_order: 15
 ---
 
 {: .no_toc}

--- a/docs/clean-core/architectural-concepts.md
+++ b/docs/clean-core/architectural-concepts.md
@@ -3,10 +3,6 @@ layout: page
 title: Architekturkonzepte
 permalink: /clean-core/architectural-concepts/
 parent: Clean Core
-prev_page_link: /clean-core/problems-and-challenges/
-prev_page_title: Problemfelder und Herausforderungen
-next_page_link: /clean-core/solution-approach/
-next_page_title: Lösungsansatz
 nav_order: 4
 ---
 

--- a/docs/clean-core/index.md
+++ b/docs/clean-core/index.md
@@ -2,8 +2,6 @@
 layout: page
 title: Clean Core
 permalink: /clean-core/
-next_page_link: /clean-core/what-is-clean-core/
-next_page_title: Was ist Clean Core
 has_children: true
 nav_order: 7
 ---

--- a/docs/clean-core/problems-and-challenges.md
+++ b/docs/clean-core/problems-and-challenges.md
@@ -3,10 +3,6 @@ layout: page
 title: Problemfelder und Herausforderungen
 permalink: /clean-core/problems-and-challenges/
 parent: Clean Core
-prev_page_link: /clean-core/why-clean-core/
-prev_page_title: Warum Clean Core
-next_page_link: /clean-core/architectural-concepts/
-next_page_title: Architekturkonzepte
 nav_order: 3
 ---
 

--- a/docs/clean-core/solution-approach.md
+++ b/docs/clean-core/solution-approach.md
@@ -3,8 +3,6 @@ layout: page
 title: Lösungsansatz
 permalink: /clean-core/solution-approach/
 parent: Clean Core
-prev_page_link: /clean-core/architectural-concepts/
-prev_page_title: Architekturkonzepte
 nav_order: 5
 ---
 

--- a/docs/clean-core/what-is-clean-core.md
+++ b/docs/clean-core/what-is-clean-core.md
@@ -3,10 +3,6 @@ layout: page
 title: Was ist Clean Core
 permalink: /clean-core/what-is-clean-core/
 parent: Clean Core
-prev_page_link: /clean-core/
-prev_page_title: Clean Core
-next_page_link: /clean-core/why-clean-core/
-next_page_title: Warum Clean Core
 nav_order: 1
 ---
 

--- a/docs/clean-core/why-clean-core.md
+++ b/docs/clean-core/why-clean-core.md
@@ -3,10 +3,6 @@ layout: page
 title: Warum Clean Core
 permalink: /clean-core/why-clean-core/
 parent: Clean Core
-prev_page_link: /clean-core/what-is-clean-core/
-prev_page_title: Was ist Clean Core
-next_page_link: /clean-core/problems-and-challenges/
-next_page_title: Problemfelder und Herausforderungen
 nav_order: 2
 ---
 

--- a/docs/core-data-services/index.md
+++ b/docs/core-data-services/index.md
@@ -2,8 +2,7 @@
 layout: page
 title: Core Data Services
 permalink: /core-data-services/
-next_page_title: Core Data Services
-nav_order: 10
+nav_order: 11
 ---
 
 {: .no_toc}

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -2,7 +2,6 @@
 layout: page
 title: Dokumentation
 permalink: /documentation/
-next_page_title: Dokumentation
 nav_order: 1
 ---
 

--- a/docs/forms/index.md
+++ b/docs/forms/index.md
@@ -2,8 +2,7 @@
 layout: page
 title: Formulare
 permalink: /forms/
-next_page_title: Formulare
-nav_order: 11
+nav_order: 12
 ---
 
 {: .no_toc}

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,5 +13,5 @@ Wenn Sie einen Beitrag leisten möchten, besuchen Sie das GitHub Repository:
 
 Der DSAG ABAP Leitfaden ist ein lebendiges Dokument 👨‍💻 - es lebt von und mit seiner Community 🥳.
 
-{: .note}
-Aktuell befindet sich der Leitfaden in Erstellung und wurde noch keinem Review unterzogen. Es können daher fehlerhafte, lückenhafte oder unvollständige Informationen enthalten sein.
+{% capture disclaimer %}{% include wip-disclaimer.md %}{% endcapture %}
+{{ disclaimer | markdownify }}

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -2,8 +2,7 @@
 layout: page
 title: Integration
 permalink: /integration/
-next_page_title: Integration
-nav_order: 9
+nav_order: 10
 ---
 
 {: .no_toc}

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -2,7 +2,6 @@
 layout: page
 title: Einleitung
 permalink: /introduction/
-next_page_title: Einführung
 nav_order: 0
 ---
 

--- a/docs/open-source/abapgit-as-enabler.md
+++ b/docs/open-source/abapgit-as-enabler.md
@@ -3,10 +3,6 @@ layout: page
 title: abapGit als Enabler von Open Source
 permalink: /open-source/abapgit-as-enabler/
 parent: Open Source
-prev_page_link: /open-source/developing-open-source/
-prev_page_title: Entwicklung von Open Source
-next_page_link: /open-source/open-source-projects/
-next_page_title: Vorstellung ausgewählter Projekte
 nav_order: 4
 ---
 

--- a/docs/open-source/contributing-to-open-source.md
+++ b/docs/open-source/contributing-to-open-source.md
@@ -3,10 +3,6 @@ layout: page
 title: Beteiligung an Open Source
 permalink: /open-source/contributing-to-open-source/
 parent: Open Source
-prev_page_link: /open-source/using-open-source/
-prev_page_title: Einsatz von Open Source
-next_page_link: /open-source/developing-open-source/
-next_page_title: Entwicklung von Open Source
 nav_order: 2
 ---
 

--- a/docs/open-source/developing-open-source.md
+++ b/docs/open-source/developing-open-source.md
@@ -3,10 +3,6 @@ layout: page
 title: Entwicklung von Open Source
 permalink: /open-source/developing-open-source/
 parent: Open Source
-prev_page_link: /open-source/contributing-to-open-source/
-prev_page_title: Beteiligung an Open Source
-next_page_link: /open-source/abapgit-as-enabler/
-next_page_title: abapGit als Enabler von Open Source
 nav_order: 3
 ---
 

--- a/docs/open-source/index.md
+++ b/docs/open-source/index.md
@@ -2,8 +2,6 @@
 layout: page
 title: Open Source
 permalink: /open-source/
-next_page_link: /open-source/using-open-source/
-next_page_title: Einsatz von Open Source
 has_children: true
 nav_order: 5
 ---

--- a/docs/open-source/open-source-projects.md
+++ b/docs/open-source/open-source-projects.md
@@ -3,8 +3,6 @@ layout: page
 title: Vorstellung ausgewählter Projekte
 permalink: /open-source/open-source-projects/
 parent: Open Source
-prev_page_link: /open-source/abapgit-as-enabler/
-prev_page_title: abapGit als Enabler von Open Source
 nav_order: 5
 ---
 

--- a/docs/open-source/using-open-source.md
+++ b/docs/open-source/using-open-source.md
@@ -3,10 +3,6 @@ layout: page
 title: Einsatz von Open Source
 permalink: /open-source/using-open-source/
 parent: Open Source
-prev_page_link: /open-source/
-prev_page_title: Open Source
-next_page_link: /open-source/contributing-to-open-source/
-next_page_title: Beteiligung an Open-Source
 nav_order: 1
 ---
 

--- a/docs/organization/index.md
+++ b/docs/organization/index.md
@@ -2,8 +2,7 @@
 layout: page
 title: Organisation
 permalink: /organization/
-next_page_title: Organisation
-nav_order: 13
+nav_order: 14
 ---
 
 {: .no_toc}

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -2,7 +2,6 @@
 layout: page
 title: Sicherheit
 permalink: /security/
-next_page_title: Sicherheit
 nav_order: 2
 ---
 

--- a/docs/testing/abap-unit.md
+++ b/docs/testing/abap-unit.md
@@ -3,10 +3,6 @@ layout: page
 title: ABAP Unit Framework
 permalink: /testing/abap_unit/
 parent: Testen
-prev_page_link: /testing/
-prev_page_title: Testen
-next_page_link: /testing/other-test-tools/
-next_page_title: Andere Test Tools
 nav_order: 1
 ---
 

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -2,10 +2,8 @@
 layout: page
 title: Testen
 permalink: /testing/
-next_page_title: ABAP Unit Framework
-next_page_link: /testing/abap_unit/
 has_children: true
-nav_order: 8
+nav_order: 9
 ---
 
 {: .no_toc}

--- a/docs/testing/other-test-tools.md
+++ b/docs/testing/other-test-tools.md
@@ -3,10 +3,6 @@ layout: page
 title: Andere Test Tools
 permalink: /testing/other-test-tools/
 parent: Testen
-prev_page_link: /testing/abap_unit/
-prev_page_title: ABAP Unit Framework
-next_page_link: /testing/recommended-tools/
-next_page_title: Empfehlungen für Testwerkzeuge
 nav_order: 2
 ---
 

--- a/docs/testing/recommended-tools.md
+++ b/docs/testing/recommended-tools.md
@@ -3,8 +3,6 @@ layout: page
 title: Empfehlungen für Testwerkzeuge
 permalink: /testing/recommended-tools/
 parent: Testen
-prev_page_link: /testing/other-test-tools/
-prev_page_title: Andere Test Tools
 nav_order: 3
 ---
 

--- a/docs/user-interface/index.md
+++ b/docs/user-interface/index.md
@@ -2,8 +2,7 @@
 layout: page
 title: UI
 permalink: /user-interface/
-next_page_title: UI
-nav_order: 7
+nav_order: 8
 ---
 
 {: .no_toc}

--- a/docs/version-management/index.md
+++ b/docs/version-management/index.md
@@ -2,7 +2,6 @@
 layout: page
 title: Versionsverwaltung
 permalink: /version-management/
-next_page_title: Versionsverwaltung
 nav_order: 6
 ---
 


### PR DESCRIPTION
Ich hab ein Include gebaut, um Jekyll die Links zur letzten und zur nächsten Seite automatisch bestimmen zu lassen (anhand der `nav_order`). Damit kann die Angabe von 

```
prev_page_link: /abap/
prev_page_title: Moderne ABAP Entwicklung
next_page_link: /abap/clean_and_modern_abap/
next_page_title: Sauberer und moderner ABAP Code
```

im Frontmatter der einzelnen Seiten wegfallen.

Die Lösung funktioniert nur, solange wir keine dritte Navigationsebene einführen. Das hier funktioniert also:
```
abap/
├─ architecture/
├─ modern abap/
```

Das hier aber nicht (ließe sich bei Bedarf aber auch entwickeln):
```
tests/
├─ abap unit/
│  ├─ how to mock/
```

Dafür vermeiden wir so die aufwendige Pflege der Links und Seitentitel der Nachbarn :-) 

Die Umsetzung ist ein bisschen hacky, schöner hab ich es aber in Liquid nicht hinbekommen.

Mir ist dabei aufgefallen, dass UI und Clean Core beide `nav_order: 7` im Frontmatter angegeben hatten, ich habe UI und alle folgenden Seiten jeweils um einen hochgezählt, damit die Reihenfolge wieder eindeutig ist.

Theoretisch müsste sich so auch das Include `toc_landing_page.html` vereinfachen lassen.