### PR TITLE
Fix build action for PR #90

### DIFF
--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -23,13 +23,13 @@
     {% if previous_page %}
     <span class="prev float-left">
         ←
-        <a href="{% link {{ previous_page.path }} %}">{{ previous_page.title }}</a>
+        <a href="{{site.baseurl}}{{ previous_page.url }}">{{ previous_page.title }}</a>
     </span>
     {% endif %} 
 
     {% if next_page %}
     <span class="next float-right">
-        <a href="{% link {{ next_page.path }} %}">{{ next_page.title }}</a>
+        <a href="{{site.baseurl}}{{ next_page.url }}">{{ next_page.title }}</a>
         →
     </span>
     {% endif %}

--- a/docs/_includes/get_page_navigation
+++ b/docs/_includes/get_page_navigation
@@ -23,7 +23,8 @@ previous_page:      previous page in nav order (or parent, if it is the first pa
 {%- endcomment -%}
 
 {% assign top_pages = site.pages
-| where_exp: "item", "item.title != nil and item.parent == nil"
+| where_exp: "item", "item.title != nil"
+| where_exp: "item", "item.parent == nil"
 | sort: "nav_order"
 %}
 
@@ -47,7 +48,8 @@ previous_page:      previous page in nav order (or parent, if it is the first pa
 
 {% for top_page in top_pages %}
     {% assign _curr_children = site.pages
-    | where_exp: "item", "item.title != nil and item.parent == top_page.title"
+    | where_exp: "item", "item.title != nil"
+    | where_exp: "item", "item.parent == top_page.title"
     | sort: "nav_order" %}
 
     {% assign top_child_pages = top_child_pages | push: _curr_children %}
@@ -60,7 +62,8 @@ previous_page:      previous page in nav order (or parent, if it is the first pa
 
 {% if is_top_page == 1 %}
     {% assign _children_of_this_page = site.pages
-        | where_exp: "item", "item.title != nil and item.parent == page.title"
+        | where_exp: "item", "item.title != nil"
+        | where_exp: "item", "item.parent == page.title"
         | sort: "nav_order" %}
     {% assign first_child = _children_of_this_page | first %}
 {% endif %}


### PR DESCRIPTION
Durch #90 schlägt der Build der Github Pages fehl. Grund scheint eine unterschiedliche Version von Jekyll/Liquid im lokalen Environment und im Build-Schritt zu sein.

Ich hab die Bestimmung der Links zur Navigation so angepasst, dass sie auch mit der im Build verwendeten Version kompatibel ist, damit sollte die Action wieder funktionieren.

Bei mir lokal funktioniert der Build-Schritt nun (deploy habe ich nicht eingerichtet, aber da sollte sich nichts geändert haben).

![image](https://github.com/user-attachments/assets/89de6569-2281-4e37-b1e0-6e02b1e47e39)
