### PR TITLE
Fix ABAP Cleaner link placement in documentation

### DIFF
--- a/docs/abap/clean_and_modern_abap.md
+++ b/docs/abap/clean_and_modern_abap.md
@@ -459,8 +459,8 @@ Entwicklungsobjekt eingesetzt werden.
 
 ## ABAP Cleaner
 
-Der 2023 öffentlich erschienene ABAP Cleaner ist eine Erweiterung für ADT, welche die Anwendung von mehr als 90 Regeln zur Formatierung und Gestaltung von ABAP Code ermöglicht.
-[ABAP Cleaner Link](https://github.com/SAP/abap-cleaner)
+Der 2023 öffentlich erschienene [ABAP Cleaner Link](https://github.com/SAP/abap-cleaner) ist eine Erweiterung für ADT, welche die Anwendung von mehr als 90 Regeln zur Formatierung und Gestaltung von ABAP Code ermöglicht.
+
 ABAP Code wird nicht nur wie bei Pretty Printer formatiert, es werden auch, basierend auf den eingestellten Regeln, Optimierungen des ABAP Codes vorgenommen.
 Nicht verwendete Methoden-Parameter werden durch Kommentare kenntlich gemacht und es können - je nach Einstellung - nicht verwendete Variablen automatisch gelöscht werden.
 Das Ergebnis der Anwendung ist einheitlicher, besser lesbarer Code und eine effektive Beschleunigung der Entwicklung, da der Cleaner Aufgaben des Programmierers übernimmt.


### PR DESCRIPTION
Der Link zu ABAP Cleaner stand etwas verloren im Text

Der Link ist jetzt am Anfang des Fliesstextes. Dazu einen Absatz nach der ABAP Cleaner Einführung eingefügt. Das sollte die Lesbarkeit erleichtern.